### PR TITLE
[FEAT] 그래프 데이터 뷰모델 통합관리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-    buildFeatures{
-         dataBinding = true
+    buildFeatures {
+        dataBinding = true
     }
 }
 
@@ -77,4 +77,7 @@ dependencies {
 
     // Timber
     implementation "com.jakewharton.timber:timber:$timberVersion"
+
+    // MPAndroidChart
+    implementation "com.github.PhilJay:MPAndroidChart:v$chartVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-feature android:name="android.hardware.sensor.accelerometer" />
     <uses-feature android:name="android.hardware.sensor.gyroscoper" />
 
+    <uses-permission
+        android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"
+        tools:ignore="HighSamplingRate" />
     <application
         android:name=".common.SensorApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/preonboarding/sensordashboard/common/constant/Constants.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/common/constant/Constants.kt
@@ -2,4 +2,7 @@ package com.preonboarding.sensordashboard.common.constant
 
 object Constants {
     const val DB_NAME = "sensor_history_database"
+    const val X = 0
+    const val Y = 1
+    const val Z = 2
 }

--- a/app/src/main/java/com/preonboarding/sensordashboard/domain/model/MeasureValue.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/domain/model/MeasureValue.kt
@@ -1,0 +1,7 @@
+package com.preonboarding.sensordashboard.domain.model
+
+data class MeasureValue(
+    val x: Float = 0F,
+    val y: Float = 0F,
+    val z: Float = 0F
+)

--- a/app/src/main/java/com/preonboarding/sensordashboard/presentation/adapter/GraphBindingAdapter.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/presentation/adapter/GraphBindingAdapter.kt
@@ -1,0 +1,9 @@
+package com.preonboarding.sensordashboard.presentation.adapter
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+
+@BindingAdapter("bindValue")
+fun TextView.bindValue(value: Float) {
+    text = value.toString()
+}

--- a/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
@@ -14,8 +14,10 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.github.mikephil.charting.components.Legend
 import com.preonboarding.sensordashboard.R
 import com.preonboarding.sensordashboard.common.base.BaseFragment
+import com.preonboarding.sensordashboard.common.constant.Constants.X
+import com.preonboarding.sensordashboard.common.constant.Constants.Y
+import com.preonboarding.sensordashboard.common.constant.Constants.Z
 import com.preonboarding.sensordashboard.databinding.FragmentSensorHistoryMeasureBinding
-import com.preonboarding.sensordashboard.domain.model.SensorHistory
 import com.preonboarding.sensordashboard.presentation.viewmodel.SensorHistoryMeasureViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -40,28 +42,28 @@ class SensorHistoryMeasureFragment :
     lateinit var sensorManager: SensorManager
 
     private lateinit var sensor: Sensor
+
     private val sensorHistoryMeasureViewModel: SensorHistoryMeasureViewModel by activityViewModels()
     private val format = DecimalFormat("#.####")
-    private lateinit var history: SensorHistory
+
     private var xList = mutableListOf<Float>()
     private var yList = mutableListOf<Float>()
     private var zList = mutableListOf<Float>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.vm = sensorHistoryMeasureViewModel
-
-        sensorManager = requireActivity().getSystemService(Context.SENSOR_SERVICE) as SensorManager
         collectFlow()
         initView()
         initChart()
     }
+
     private fun registerSensorListener(listener: SensorEventListener, sensor: Sensor) {
         sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_FASTEST)
     }
 
     private fun initView() {
         binding.apply {
+            vm = sensorHistoryMeasureViewModel
             tvHistoryMeasureStart.setOnClickListener {
                 Toast.makeText(it.context, "측정 시작", Toast.LENGTH_SHORT).show()
                 setMeasureButtonClickable(false)
@@ -173,15 +175,10 @@ class SensorHistoryMeasureFragment :
     }
 
     private fun getSensorData(event: SensorEvent) {
-
-        binding.tvHistoryMeasureX.text = format.format(event.values[0]).toString() //x축
-        binding.tvHistoryMeasureY.text = format.format(event.values[1]).toString() //y축
-        binding.tvHistoryMeasureZ.text = format.format(event.values[2]).toString() //z축
-
         sensorHistoryMeasureViewModel.updateCurrentMeasureValue(
-            event.values[0],
-            event.values[1],
-            event.values[2]
+            event.values[X],
+            event.values[Y],
+            event.values[Z]
         )
 
         xList.add(format.format(event.values[0]).toFloat())

--- a/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
@@ -1,6 +1,5 @@
 package com.preonboarding.sensordashboard.presentation.view.sensor_history_measure
 
-import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -8,13 +7,18 @@ import android.hardware.SensorManager
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.github.mikephil.charting.components.Legend
 import com.preonboarding.sensordashboard.R
 import com.preonboarding.sensordashboard.common.base.BaseFragment
 import com.preonboarding.sensordashboard.databinding.FragmentSensorHistoryMeasureBinding
 import com.preonboarding.sensordashboard.domain.model.SensorHistory
 import com.preonboarding.sensordashboard.presentation.viewmodel.SensorHistoryMeasureViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.text.DecimalFormat
 import javax.inject.Inject
@@ -22,13 +26,21 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SensorHistoryMeasureFragment :
     BaseFragment<FragmentSensorHistoryMeasureBinding>(R.layout.fragment_sensor_history_measure) {
-    private lateinit var sensorEventListener: SensorEventListener
+    private val sensorEventListener: SensorEventListener by lazy {
+        object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                getSensorData(event)
+            }
+
+            override fun onAccuracyChanged(p0: Sensor?, p1: Int) {}
+        }
+    }
 
     @Inject
     lateinit var sensorManager: SensorManager
 
     private lateinit var sensor: Sensor
-    private val sensorHistoryMeasureViewModel: SensorHistoryMeasureViewModel by viewModels()
+    private val sensorHistoryMeasureViewModel: SensorHistoryMeasureViewModel by activityViewModels()
     private val format = DecimalFormat("#.####")
     private lateinit var history: SensorHistory
     private var xList = mutableListOf<Float>()
@@ -37,63 +49,90 @@ class SensorHistoryMeasureFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        sensorManager = requireActivity().getSystemService(Context.SENSOR_SERVICE) as SensorManager
-        initListener()
+        collectFlow()
         initView()
-
+        initChart()
     }
-
-    private fun initListener() {
-        sensorEventListener = object : SensorEventListener {
-            override fun onSensorChanged(event: SensorEvent) {
-                //수정?
-                when (event.sensor.type) {
-                    Sensor.TYPE_ACCELEROMETER -> getSensorData(event)
-                    Sensor.TYPE_GYROSCOPE -> getSensorData(event)
-                }
-            }
-
-            override fun onAccuracyChanged(p0: Sensor?, p1: Int) {}
-
-        }
-    }
-
 
     private fun registerSensorListener(listener: SensorEventListener, sensor: Sensor) {
-        sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_FASTEST)
     }
 
-
     private fun initView() {
-        //저장btn
-
         binding.apply {
             tvHistoryMeasureStart.setOnClickListener {
                 Toast.makeText(it.context, "측정 시작", Toast.LENGTH_SHORT).show()
                 setMeasureButtonClickable(false)
+                registerSensorListener(sensorEventListener, sensor)
                 setTimer()
             }
 
             tvHistoryMeasureStop.setOnClickListener {
                 Toast.makeText(it.context, "측정 중지", Toast.LENGTH_SHORT).show()
                 setMeasureButtonClickable(true)
+                sensorManager.unregisterListener(sensorEventListener)
                 sensorHistoryMeasureViewModel.timerStop()
             }
 
             btnHistoryAccMeasure.setOnClickListener {
-                setSensorListener(Sensor.TYPE_ACCELEROMETER)
+                refreshData()
+                setSensorType(Sensor.TYPE_ACCELEROMETER)
                 Toast.makeText(it.context, "ACC", Toast.LENGTH_SHORT).show()
             }
 
             btnHistoryGyroMeasure.setOnClickListener {
-                setSensorListener(Sensor.TYPE_GYROSCOPE)
+                refreshData()
+                setSensorType(Sensor.TYPE_GYROSCOPE)
                 Toast.makeText(it.context, "GYRO", Toast.LENGTH_SHORT).show()
             }
-
         }
+    }
 
+    private fun initChart() {
+        // TODO 차트 세팅 필요 정호님에게 맡기겠습니다
+        binding.chartView.apply {
+            xAxis.apply {
+                axisMaximum = 300f
+                granularity = 1f
+                isGranularityEnabled = true
+            }
+            axisRight.isEnabled = false
+            axisLeft.apply {
+                axisMaximum = 25f
+                axisMinimum = -25f
+            }
+            legend.horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
+        }
+        //
+        sensorHistoryMeasureViewModel.initLineData()
+        binding.chartView.data = sensorHistoryMeasureViewModel.lineData
+    }
 
+    private fun collectFlow() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                sensorHistoryMeasureViewModel.currentMeasureValue.collect() { measureValue ->
+                    sensorHistoryMeasureViewModel.addEntry(
+                        measureValue.x,
+                        measureValue.y,
+                        measureValue.z
+                    )
+                    binding.chartView.apply {
+                        notifyDataSetChanged()
+                        invalidate()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun refreshData() {
+        binding.chartView.apply {
+            data.clearValues()
+            invalidate()
+        }
+        sensorHistoryMeasureViewModel.initLineData()
+        binding.chartView.data = sensorHistoryMeasureViewModel.lineData
     }
 
     private fun setMeasureButtonClickable(state: Boolean) {
@@ -103,10 +142,9 @@ class SensorHistoryMeasureFragment :
         }
     }
 
-    private fun setSensorListener(sensorType: Int) {
+    private fun setSensorType(sensorType: Int) {
         sensorManager.unregisterListener(sensorEventListener)
         sensor = sensorManager.getDefaultSensor(sensorType)
-        registerSensorListener(sensorEventListener, sensor)
     }
 
     private fun setTimer() {
@@ -132,16 +170,25 @@ class SensorHistoryMeasureFragment :
         sensorHistoryMeasureViewModel.timerStart(timerAction)
     }
 
-
     private fun getSensorData(event: SensorEvent) {
 
         binding.tvHistoryMeasureX.text = format.format(event.values[0]).toString() //x축
         binding.tvHistoryMeasureY.text = format.format(event.values[1]).toString() //y축
         binding.tvHistoryMeasureZ.text = format.format(event.values[2]).toString() //z축
 
+        sensorHistoryMeasureViewModel.updateCurrentMeasureValue(
+            event.values[0],
+            event.values[1],
+            event.values[2]
+        )
+
         xList.add(format.format(event.values[0]).toFloat())
         yList.add(format.format(event.values[1]).toFloat())
         zList.add(format.format(event.values[2]).toFloat())
     }
 
+    override fun onStop() {
+        sensorManager.unregisterListener(sensorEventListener)
+        super.onStop()
+    }
 }

--- a/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/presentation/view/sensor_history_measure/SensorHistoryMeasureFragment.kt
@@ -58,7 +58,7 @@ class SensorHistoryMeasureFragment :
     }
 
     private fun registerSensorListener(listener: SensorEventListener, sensor: Sensor) {
-        sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_FASTEST)
+        sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
     }
 
     private fun initView() {
@@ -96,7 +96,7 @@ class SensorHistoryMeasureFragment :
         // TODO 차트 세팅 필요 정호님에게 맡기겠습니다
         binding.chartView.apply {
             xAxis.apply {
-                axisMaximum = 300f
+                axisMaximum = 600f
                 granularity = 1f
                 isGranularityEnabled = true
             }

--- a/app/src/main/java/com/preonboarding/sensordashboard/presentation/viewmodel/SensorHistoryMeasureViewModel.kt
+++ b/app/src/main/java/com/preonboarding/sensordashboard/presentation/viewmodel/SensorHistoryMeasureViewModel.kt
@@ -1,11 +1,23 @@
 package com.preonboarding.sensordashboard.presentation.viewmodel
 
+import android.graphics.Color
 import androidx.lifecycle.viewModelScope
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet
 import com.preonboarding.sensordashboard.common.base.BaseViewModel
+import com.preonboarding.sensordashboard.common.constant.Constants.X
+import com.preonboarding.sensordashboard.common.constant.Constants.Y
+import com.preonboarding.sensordashboard.common.constant.Constants.Z
+import com.preonboarding.sensordashboard.domain.model.MeasureValue
 import com.preonboarding.sensordashboard.domain.usecase.SaveSensorHistoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,6 +29,67 @@ class SensorHistoryMeasureViewModel @Inject constructor(
     private lateinit var job: Job
     private var interval: Long = 100
 
+    private val _currentMeasureValue = MutableStateFlow(MeasureValue())
+    val currentMeasureValue = _currentMeasureValue.asStateFlow()
+
+    var lineData: LineData = LineData()
+    private val lineDataSet = ArrayList<ILineDataSet>()
+    private lateinit var xEntries: ArrayList<Entry>
+    private lateinit var yEntries: ArrayList<Entry>
+    private lateinit var zEntries: ArrayList<Entry>
+
+    fun initLineData() {
+        xEntries = arrayListOf(Entry(0f, 0f))
+        yEntries = arrayListOf(Entry(0f, 0f))
+        zEntries = arrayListOf(Entry(0f, 0f))
+        lineDataSet.apply {
+            add(getLineDataSet(xEntries, "x", Color.RED))
+            add(getLineDataSet(yEntries, "y", Color.GREEN))
+            add(getLineDataSet(zEntries, "z", Color.BLUE))
+        }
+        lineData = LineData(lineDataSet)
+    }
+
+    fun addEntry(x: Float, y: Float, z: Float) {
+        lineData.apply {
+            dataSets[X].addEntry(Entry(dataSets[X].entryCount.toFloat(), x))
+            dataSets[Y].addEntry(Entry(dataSets[Y].entryCount.toFloat(), y))
+            dataSets[Z].addEntry(Entry(dataSets[Z].entryCount.toFloat(), z))
+            notifyDataChanged()
+        }
+    }
+
+    private fun getLineDataSet(
+        entries: ArrayList<Entry>,
+        type: String,
+        colorType: Int
+    ): LineDataSet {
+        // TODO 데이터세트 세팅 필요
+        // 정호님 화이팅
+        return LineDataSet(entries, type).apply {
+            color = colorType
+            setCircleColor(colorType)
+            circleHoleColor = colorType
+            lineWidth = 1f
+            circleRadius = 1f
+            isHighlightEnabled = false
+            mode = LineDataSet.Mode.HORIZONTAL_BEZIER
+        }
+    }
+
+    fun updateCurrentMeasureValue(x: Float, y: Float, z: Float) {
+        viewModelScope.launch {
+            _currentMeasureValue.update {
+                _currentMeasureValue.value.copy(x, y, z)
+            }
+        }
+    }
+
+    // 선택된 히스토리 데이터 초기화용
+    fun setLineData(){
+        initLineData()
+        //TODO Item 넘겨받아 뷰모델 lineData 세팅 필요
+    }
 
     fun timerStart(fnCallback: () -> Unit) {
         isRun = true

--- a/app/src/main/res/layout/fragment_sensor_history_measure.xml
+++ b/app/src/main/res/layout/fragment_sensor_history_measure.xml
@@ -75,12 +75,10 @@
             app:layout_constraintStart_toEndOf="@id/btn_history_acc_measure"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <View
-            android:id="@+id/view_history_measure_canvas"
-            android:layout_width="0dp"
+        <com.github.mikephil.charting.charts.LineChart
+            android:id="@+id/chart_view"
+            android:layout_width="match_parent"
             android:layout_height="350dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_history_measure_x" />
 
         <TextView
@@ -95,7 +93,7 @@
             app:layout_constraintBottom_toTopOf="@id/tv_history_measure_stop"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/view_history_measure_canvas" />
+            app:layout_constraintTop_toBottomOf="@id/chart_view" />
 
         <TextView
             android:id="@+id/tv_history_measure_stop"

--- a/app/src/main/res/layout/fragment_sensor_history_measure.xml
+++ b/app/src/main/res/layout/fragment_sensor_history_measure.xml
@@ -19,9 +19,9 @@
             android:id="@+id/cl_main"
             android:layout_width="0dp"
             android:layout_height="?attr/actionBarSize"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintTop_toTopOf="parent">
 
             <ImageView
                 android:id="@+id/iv_back"
@@ -30,33 +30,33 @@
                 android:contentDescription="@string/back"
                 android:paddingHorizontal="12dp"
                 android:src="@drawable/ic_arrow_back_24"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:navigateUp="@{null}" />
 
             <TextView
-                style="@style/ToolbarTitle"
                 android:id="@+id/tv_title"
+                style="@style/ToolbarTitle"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:gravity="center"
                 android:text="@string/do_measure"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                style="@style/ToolbarMenu"
                 android:id="@+id/tv_menu"
+                style="@style/ToolbarMenu"
                 android:layout_width="wrap_content"
                 android:layout_height="0dp"
                 android:paddingHorizontal="12dp"
                 android:text="@string/save"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent" />
+                app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -65,71 +65,73 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/Accelerator"
-            app:layout_constraintTop_toBottomOf="@id/cl_main"
+            app:layout_constraintEnd_toStartOf="@id/btn_history_gyro_measure"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/btn_history_gyro_measure" />
+            app:layout_constraintTop_toBottomOf="@id/cl_main" />
 
         <TextView
             android:id="@+id/tv_history_timer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="30sp"
-            app:layout_constraintTop_toBottomOf="@id/cl_main"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/cl_main" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_history_gyro_measure"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/Gyroscope"
-            app:layout_constraintTop_toBottomOf="@id/cl_main"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/btn_history_acc_measure"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/cl_main" />
 
         <TextView
             android:id="@+id/tv_history_measure_x"
+            bindValue="@{vm.currentMeasureValue.x}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="@string/x"
             android:textColor="@color/xRed"
             android:textSize="30sp"
-            app:layout_constraintTop_toBottomOf="@id/tv_history_timer"
+            app:layout_constraintEnd_toStartOf="@id/tv_history_measure_y"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/tv_history_measure_y" />
+            app:layout_constraintTop_toBottomOf="@id/tv_history_timer"
+            tools:text="@string/x" />
 
         <TextView
             android:id="@+id/tv_history_measure_y"
+            bindValue="@{vm.currentMeasureValue.x}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/y"
             android:textColor="@color/yGreen"
             android:textSize="30sp"
-            app:layout_constraintTop_toTopOf="@id/tv_history_measure_x"
-            app:layout_constraintStart_toEndOf="@id/tv_history_measure_x"
+            app:layout_constraintBottom_toBottomOf="@id/tv_history_measure_x"
             app:layout_constraintEnd_toStartOf="@id/tv_history_measure_z"
-            app:layout_constraintBottom_toBottomOf="@id/tv_history_measure_x" />
+            app:layout_constraintStart_toEndOf="@id/tv_history_measure_x"
+            app:layout_constraintTop_toTopOf="@id/tv_history_measure_x"
+            tools:text="@string/y" />
 
         <TextView
             android:id="@+id/tv_history_measure_z"
+            bindValue="@{vm.currentMeasureValue.x}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/z"
             android:textColor="@color/zBlue"
             android:textSize="30sp"
-            app:layout_constraintTop_toTopOf="@id/tv_history_measure_x"
-            app:layout_constraintStart_toEndOf="@id/tv_history_measure_y"
+            app:layout_constraintBottom_toBottomOf="@id/tv_history_measure_x"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="@id/tv_history_measure_x" />
+            app:layout_constraintStart_toEndOf="@id/tv_history_measure_y"
+            app:layout_constraintTop_toTopOf="@id/tv_history_measure_x"
+            tools:text="@string/z" />
 
         <com.github.mikephil.charting.charts.LineChart
             android:id="@+id/chart_view"
             android:layout_width="match_parent"
             android:layout_height="350dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_history_measure_x"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
             app:layout_constraintTop_toBottomOf="@id/tv_history_measure_x" />
 
         <TextView
@@ -141,10 +143,8 @@
             android:text="@string/measure"
             android:textSize="30sp"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/view_history_measure_canvas"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/tv_history_measure_stop"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/tv_history_measure_stop" />
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/chart_view" />
 
@@ -157,10 +157,10 @@
             android:text="@string/measure_stop"
             android:textSize="30sp"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/tv_history_measure_start"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_history_measure_start" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         glideVersion = '4.13.0'
         pagingVersion = "3.1.1"
         timberVersion = '5.0.1'
+        chartVersion = "3.1.0"
     }
 
     dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = "https://jitpack.io" }
     }
 }
 rootProject.name = "android-wanted-SensorDashboardApp"


### PR DESCRIPTION
## 🔥 관련 이슈

#14
#3

## 🔥 PR Point

- 그래프를 그릴 데이터를 뷰모델에서 관리합니다. 
- 센서 리스너를 분리하였습니다.
- 뷰의 Chart와 뷰모델의 LineDataSet의 세팅이 필요합니다.
- 센서 변동값을 바로 적용하지 않고 뷰모델에 저장후 collect하는 방식으로 그래프를 그리고 있습니다
- 차트관련 데이터는 뷰모델의 lineData 필드로 바로 접근하여 사용하면 됩니다.

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|뷰모델의 LineDataSet 세팅 필요부분|<img src = "https://user-images.githubusercontent.com/86879099/192977062-bdec1d77-4a98-498e-b6e1-b63d764000e2.png" width = 400>|
|뷰 차트 세팅 필요부분| <img src = "https://user-images.githubusercontent.com/86879099/192977510-0b840b51-41fd-4701-97ea-470d0d6d49ed.png" width = 400>|
|뷰모델의 데이터 세팅 필요 분| <img src = "https://user-images.githubusercontent.com/86879099/192978311-11dc0f37-3068-4261-bb14-3d94a8191bce.png" width = 400>|

## ❗TODO
- UI를 구현해야 합니다.
- 변동값 Rate를 바꿀 수 있는지 확인후 collect 하는 방식을 수정해야 할 것 같습니다.
- 선택된 히스토리를 뷰모델의 Datat에 매핑하는 작업이 필요합니다.
